### PR TITLE
update text-domain and remove languages folder

### DIFF
--- a/ele-custom-skin.php
+++ b/ele-custom-skin.php
@@ -6,8 +6,7 @@
  * Plugin URI: https://www.eletemplator.com
  * Author: Liviu Duda
  * Author URI: https://www.leadpro.ro
- * Text Domain: elecustomskin
- * Domain Path: /languages
+ * Text Domain: ele-custom-skin
  * License: GPLv3
  * License URI: http://www.gnu.org/licenses/gpl-3.0
 */


### PR DESCRIPTION
The best practice is to use text-domain that matches the plugin slug in the plugin directory.

In addition, in the past we added MO/PO translation files to the plugin. But now we use https://translate.wordpress.org/projects/wp-plugins/ele-custom-skin/. You don't need to set a language folder.